### PR TITLE
Add tiled target versions

### DIFF
--- a/makefile
+++ b/makefile
@@ -9,7 +9,7 @@ EXES= mm_testbed$(EXE)
 
 MM_OBJS  = mm_testbed.$(OBJ) mm_utils.$(OBJ) mm_tst_cases.$(OBJ) \
            mm_ijk.$(OBJ) mm_ikj.$(OBJ) mm_ikj_par.$(OBJ) \
-	   mm_gpu.$(OBJ) mm_trans.$(OBJ)
+	   mm_gpu.$(OBJ) mm_trans.$(OBJ) mm_gpu_block.$(OBJ)
 
 all: $(EXES)
 

--- a/makefile
+++ b/makefile
@@ -9,7 +9,8 @@ EXES= mm_testbed$(EXE)
 
 MM_OBJS  = mm_testbed.$(OBJ) mm_utils.$(OBJ) mm_tst_cases.$(OBJ) \
            mm_ijk.$(OBJ) mm_ikj.$(OBJ) mm_ikj_par.$(OBJ) \
-	   mm_gpu.$(OBJ) mm_trans.$(OBJ) mm_gpu_block.$(OBJ)
+	   mm_gpu.$(OBJ) mm_trans.$(OBJ) mm_gpu_block.$(OBJ) \
+           mm_gpu_block_allocate_directive.$(OBJ)
 
 all: $(EXES)
 

--- a/mm_gpu_block.c
+++ b/mm_gpu_block.c
@@ -10,7 +10,7 @@
 
 void mm_gpu_block(int Ndim, int Mdim, int Pdim, TYPE *A, TYPE *B, TYPE *C){
   int i, j, k;
-  const int Bsize = 16;
+  const int Bsize = 8;
   int ib, jb, kb;
 
   /* Block size, must evenly divide the matrices */
@@ -34,33 +34,36 @@ void mm_gpu_block(int Ndim, int Mdim, int Pdim, TYPE *A, TYPE *B, TYPE *C){
 
       for (kb=0; kb<Pblk; kb++){
 
+#pragma omp parallel num_threads(Bsize*Bsize)
+{
         /* Copy block of A into pteam memory */
-        #pragma omp parallel for collapse(2)
+        #pragma omp for collapse(2) nowait
         for (i=ib*Bsize; i<((ib+1)*Bsize); i++){
           for(k=kb*Bsize; k<((kb+1)*Bsize); k++){
             Awrk[(i%Bsize)*Bsize + (k%Bsize)] = A[i*Pdim+k];
           }
         }
 
-        /* Copy block of B into pteam memory, transposing */
-        #pragma omp parallel for collapse(2)
+        /* Copy block of B into pteam memory */
+        #pragma omp for collapse(2)
         for (j=jb*Bsize; j<((jb+1)*Bsize); j++){
           for(k=kb*Bsize; k<((kb+1)*Bsize); k++){
-            Bwrk[(j%Bsize)*Bsize + (k%Bsize)] = B[k*Mdim+j];
+            Bwrk[(k%Bsize)*Bsize + (j%Bsize)] = B[k*Mdim+j];
           }
         }
 
 
         /* matrix multiply block */
-        #pragma omp parallel for collapse(2)
+        #pragma omp for collapse(2)
         for (i=ib*Bsize; i<((ib+1)*Bsize); i++){
           for (j=jb*Bsize; j<((jb+1)*Bsize); j++){
             for(k=kb*Bsize; k<((kb+1)*Bsize); k++){
               /* C(i,j) = sum(over k) A(i,k) * B(k,j) */
-              *(C+(i*Mdim+j)) += Awrk[(i%Bsize)*Bsize + (k%Bsize)] * Bwrk[(j%Bsize)*Bsize + (k%Bsize)];
+              *(C+(i*Mdim+j)) += Awrk[(i%Bsize)*Bsize + (k%Bsize)] * Bwrk[(k%Bsize)*Bsize + (j%Bsize)];
             }
           }
         }
+}
 
       }
     }

--- a/mm_gpu_block.c
+++ b/mm_gpu_block.c
@@ -1,0 +1,43 @@
+/*
+**  function: Matrix Multiplication ... three loop, ikj case
+**            where ijk defines the order of the loops
+**
+**  HISTORY: Written by Tom Deakin, January 2021.
+*/
+#include "mm_utils.h"
+
+#include <assert.h>
+
+void mm_gpu_block(int Ndim, int Mdim, int Pdim, TYPE *A, TYPE *B, TYPE *C){
+  int i, j, k;
+  const int Bsize = 16;
+  int ib, jb, kb;
+
+  /* Block size, must evenly divide the matrices */
+  assert(Ndim % Bsize == 0);
+  assert(Mdim % Bsize == 0);
+  assert(Pdim % Bsize == 0);
+
+  /* Number of blocks in each dimension */
+  int Nblk = Ndim / Bsize;
+  int Mblk = Mdim / Bsize;
+  int Pblk = Pdim / Bsize;
+
+
+// #pragma omp target map(tofrom:C[0:Ndim*Mdim]) map(to:B[0:Pdim*Mdim],A[0:Ndim*Pdim])
+// #pragma omp teams distribute parallel for collapse(2)
+  for (ib=0; ib < Nblk; ib++){
+    for (i=ib*Bsize; i<((ib+1)*Bsize); i++){
+     for (jb=0; jb<Mblk; jb++){
+       for (j=jb*Bsize; j<((jb+1)*Bsize); j++){
+        for (kb=0; kb<Pblk; kb++){
+	  for(k=kb*Bsize; k<((kb+1)*Bsize); k++){
+	   /* C(i,j) = sum(over k) A(i,k) * B(k,j) */
+	   *(C+(i*Mdim+j)) += *(A+(i*Pdim+k)) *  *(B+(k*Mdim+j));
+          }
+	}
+       }
+     }
+   }
+  }
+}

--- a/mm_gpu_block.c
+++ b/mm_gpu_block.c
@@ -23,21 +23,46 @@ void mm_gpu_block(int Ndim, int Mdim, int Pdim, TYPE *A, TYPE *B, TYPE *C){
   int Mblk = Mdim / Bsize;
   int Pblk = Pdim / Bsize;
 
+  /* Team local arrays */
+  TYPE Awrk[Bsize*Bsize];
+  TYPE Bwrk[Bsize*Bsize];
 
-// #pragma omp target map(tofrom:C[0:Ndim*Mdim]) map(to:B[0:Pdim*Mdim],A[0:Ndim*Pdim])
-// #pragma omp teams distribute parallel for collapse(2)
-  for (ib=0; ib < Nblk; ib++){
-    for (i=ib*Bsize; i<((ib+1)*Bsize); i++){
-     for (jb=0; jb<Mblk; jb++){
-       for (j=jb*Bsize; j<((jb+1)*Bsize); j++){
-        for (kb=0; kb<Pblk; kb++){
-	  for(k=kb*Bsize; k<((kb+1)*Bsize); k++){
-	   /* C(i,j) = sum(over k) A(i,k) * B(k,j) */
-	   *(C+(i*Mdim+j)) += *(A+(i*Pdim+k)) *  *(B+(k*Mdim+j));
+ #pragma omp target map(tofrom:C[0:Ndim*Mdim]) map(to:B[0:Pdim*Mdim],A[0:Ndim*Pdim])
+ #pragma omp teams distribute collapse(2) num_teams(Nblk*Mblk) allocate(omp_pteam_mem_alloc: Awrk, Bwrk) private(Awrk, Bwrk)
+ for (ib=0; ib < Nblk; ib++){ /* Loop over blocks of C. One team per block */
+    for (jb=0; jb < Mblk; jb++){
+
+      for (kb=0; kb<Pblk; kb++){
+
+        /* Copy block of A into pteam memory */
+        #pragma omp parallel for collapse(2)
+        for (i=ib*Bsize; i<((ib+1)*Bsize); i++){
+          for(k=kb*Bsize; k<((kb+1)*Bsize); k++){
+            Awrk[(i%Bsize)*Bsize + (k%Bsize)] = A[i*Pdim+k];
           }
-	}
-       }
-     }
-   }
+        }
+
+        /* Copy block of B into pteam memory, transposing */
+        #pragma omp parallel for collapse(2)
+        for (j=jb*Bsize; j<((jb+1)*Bsize); j++){
+          for(k=kb*Bsize; k<((kb+1)*Bsize); k++){
+            Bwrk[(j%Bsize)*Bsize + (k%Bsize)] = B[k*Mdim+j];
+          }
+        }
+
+
+        /* matrix multiply block */
+        #pragma omp parallel for collapse(2)
+        for (i=ib*Bsize; i<((ib+1)*Bsize); i++){
+          for (j=jb*Bsize; j<((jb+1)*Bsize); j++){
+            for(k=kb*Bsize; k<((kb+1)*Bsize); k++){
+              /* C(i,j) = sum(over k) A(i,k) * B(k,j) */
+              *(C+(i*Mdim+j)) += Awrk[(i%Bsize)*Bsize + (k%Bsize)] * Bwrk[(j%Bsize)*Bsize + (k%Bsize)];
+            }
+          }
+        }
+
+      }
+    }
   }
 }

--- a/mm_gpu_block.c
+++ b/mm_gpu_block.c
@@ -28,7 +28,7 @@ void mm_gpu_block(int Ndim, int Mdim, int Pdim, TYPE *A, TYPE *B, TYPE *C){
   TYPE Bwrk[Bsize*Bsize];
 
  #pragma omp target map(tofrom:C[0:Ndim*Mdim]) map(to:B[0:Pdim*Mdim],A[0:Ndim*Pdim])
- #pragma omp teams distribute collapse(2) num_teams(Nblk*Mblk) allocate(omp_pteam_mem_alloc: Awrk, Bwrk) private(Awrk, Bwrk)
+ #pragma omp teams distribute collapse(2) num_teams(Nblk*Mblk) allocate(omp_pteam_mem_alloc: Awrk, Bwrk) private(Awrk, Bwrk) thread_limit(Bsize*Bsize)
  for (ib=0; ib < Nblk; ib++){ /* Loop over blocks of C. One team per block */
     for (jb=0; jb < Mblk; jb++){
 

--- a/mm_gpu_block_allocate_directive.c
+++ b/mm_gpu_block_allocate_directive.c
@@ -37,10 +37,10 @@ void mm_gpu_block(int Ndim, int Mdim, int Pdim, TYPE *A, TYPE *B, TYPE *C){
  for (int ib=0; ib < Nblk; ib++){ /* Loop over blocks of C. One team per block */
     for (int jb=0; jb < Mblk; jb++){
 
-      for (int kb=0; kb<Pblk; kb++){
 
 #pragma omp parallel num_threads(Bsize*Bsize)
 {
+      for (int kb=0; kb<Pblk; kb++){
         /* Copy block of A into pteam memory */
         #pragma omp for collapse(2) nowait schedule(static, 1)
         for (int i=ib*Bsize; i<((ib+1)*Bsize); i++){

--- a/mm_gpu_block_allocate_directive.c
+++ b/mm_gpu_block_allocate_directive.c
@@ -11,8 +11,8 @@
 #define Bsize 8
 
 void mm_gpu_block(int Ndim, int Mdim, int Pdim, TYPE *A, TYPE *B, TYPE *C){
-  int i, j, k;
-  int ib, jb, kb;
+  //int i, j, k;
+  //int ib, jb, kb;
 
   /* Block size, must evenly divide the matrices */
   assert(Ndim % Bsize == 0);
@@ -33,37 +33,37 @@ void mm_gpu_block(int Ndim, int Mdim, int Pdim, TYPE *A, TYPE *B, TYPE *C){
   TYPE Bwrk[Bsize*Bsize];
 #pragma omp allocate(Awrk, Bwrk) allocator(omp_pteam_mem_alloc)
 
-#pragma omp distribute collapse(2)
- for (ib=0; ib < Nblk; ib++){ /* Loop over blocks of C. One team per block */
-    for (jb=0; jb < Mblk; jb++){
+#pragma omp distribute collapse(2) dist_schedule(static, 1)
+ for (int ib=0; ib < Nblk; ib++){ /* Loop over blocks of C. One team per block */
+    for (int jb=0; jb < Mblk; jb++){
 
-      for (kb=0; kb<Pblk; kb++){
+      for (int kb=0; kb<Pblk; kb++){
 
 #pragma omp parallel num_threads(Bsize*Bsize)
 {
         /* Copy block of A into pteam memory */
-        #pragma omp for collapse(2) nowait
-        for (i=ib*Bsize; i<((ib+1)*Bsize); i++){
-          for(k=kb*Bsize; k<((kb+1)*Bsize); k++){
+        #pragma omp for collapse(2) nowait schedule(static, 1)
+        for (int i=ib*Bsize; i<((ib+1)*Bsize); i++){
+          for(int k=kb*Bsize; k<((kb+1)*Bsize); k++){
             Awrk[(i%Bsize)*Bsize + (k%Bsize)] = A[i*Pdim+k];
           }
         }
 
         /* Copy block of B into pteam memory */
-        #pragma omp for collapse(2)
-        for (j=jb*Bsize; j<((jb+1)*Bsize); j++){
-          for(k=kb*Bsize; k<((kb+1)*Bsize); k++){
+        #pragma omp for collapse(2) schedule(static, 1)
+        for (int j=jb*Bsize; j<((jb+1)*Bsize); j++){
+          for(int k=kb*Bsize; k<((kb+1)*Bsize); k++){
             Bwrk[(k%Bsize)*Bsize + (j%Bsize)] = B[k*Mdim+j];
           }
         }
 
 
         /* matrix multiply block */
-        #pragma omp for collapse(2)
-        for (i=ib*Bsize; i<((ib+1)*Bsize); i++){
-          for (j=jb*Bsize; j<((jb+1)*Bsize); j++){
+        #pragma omp for collapse(2) schedule(static, 1)
+        for (int i=ib*Bsize; i<((ib+1)*Bsize); i++){
+          for (int j=jb*Bsize; j<((jb+1)*Bsize); j++){
             /*for(k=kb*Bsize; k<((kb+1)*Bsize); k++){*/
-            for (k=0; k < Bsize; ++k){
+            for (int k=0; k < Bsize; ++k){
               /* C(i,j) = sum(over k) A(i,k) * B(k,j) */
               *(C+(i*Mdim+j)) += Awrk[(i%Bsize)*Bsize + k] * Bwrk[k*Bsize + (j%Bsize)];
             }

--- a/mm_gpu_block_allocate_directive.c
+++ b/mm_gpu_block_allocate_directive.c
@@ -10,7 +10,7 @@
 
 #define Bsize 8
 
-void mm_gpu_block(int Ndim, int Mdim, int Pdim, TYPE *A, TYPE *B, TYPE *C){
+void mm_gpu_block_allocate(int Ndim, int Mdim, int Pdim, TYPE *A, TYPE *B, TYPE *C){
   //int i, j, k;
   //int ib, jb, kb;
 

--- a/mm_gpu_block_allocate_directive.c
+++ b/mm_gpu_block_allocate_directive.c
@@ -33,7 +33,7 @@ void mm_gpu_block(int Ndim, int Mdim, int Pdim, TYPE *A, TYPE *B, TYPE *C){
   TYPE Bwrk[Bsize*Bsize];
 #pragma omp allocate(Awrk, Bwrk) allocator(omp_pteam_mem_alloc)
 
-#pragma omp distribute collapse(2) dist_schedule(static, 1)
+#pragma omp distribute collapse(2)
  for (int ib=0; ib < Nblk; ib++){ /* Loop over blocks of C. One team per block */
     for (int jb=0; jb < Mblk; jb++){
 
@@ -42,7 +42,7 @@ void mm_gpu_block(int Ndim, int Mdim, int Pdim, TYPE *A, TYPE *B, TYPE *C){
 {
       for (int kb=0; kb<Pblk; kb++){
         /* Copy block of A into pteam memory */
-        #pragma omp for collapse(2) nowait schedule(static, 1)
+        #pragma omp for collapse(2) nowait
         for (int i=ib*Bsize; i<((ib+1)*Bsize); i++){
           for(int k=kb*Bsize; k<((kb+1)*Bsize); k++){
             Awrk[(i%Bsize)*Bsize + (k%Bsize)] = A[i*Pdim+k];
@@ -50,7 +50,7 @@ void mm_gpu_block(int Ndim, int Mdim, int Pdim, TYPE *A, TYPE *B, TYPE *C){
         }
 
         /* Copy block of B into pteam memory */
-        #pragma omp for collapse(2) schedule(static, 1)
+        #pragma omp for collapse(2)
         for (int j=jb*Bsize; j<((jb+1)*Bsize); j++){
           for(int k=kb*Bsize; k<((kb+1)*Bsize); k++){
             Bwrk[(k%Bsize)*Bsize + (j%Bsize)] = B[k*Mdim+j];
@@ -59,7 +59,7 @@ void mm_gpu_block(int Ndim, int Mdim, int Pdim, TYPE *A, TYPE *B, TYPE *C){
 
 
         /* matrix multiply block */
-        #pragma omp for collapse(2) schedule(static, 1)
+        #pragma omp for collapse(2)
         for (int i=ib*Bsize; i<((ib+1)*Bsize); i++){
           for (int j=jb*Bsize; j<((jb+1)*Bsize); j++){
             /*for(k=kb*Bsize; k<((kb+1)*Bsize); k++){*/

--- a/mm_gpu_block_allocate_directive.c
+++ b/mm_gpu_block_allocate_directive.c
@@ -1,0 +1,78 @@
+/*
+**  function: Matrix Multiplication ... three loop, ikj case
+**            where ijk defines the order of the loops
+**
+**  HISTORY: Written by Tom Deakin, January 2021.
+*/
+#include "mm_utils.h"
+
+#include <assert.h>
+
+#define Bsize 8
+
+void mm_gpu_block(int Ndim, int Mdim, int Pdim, TYPE *A, TYPE *B, TYPE *C){
+  int i, j, k;
+  int ib, jb, kb;
+
+  /* Block size, must evenly divide the matrices */
+  assert(Ndim % Bsize == 0);
+  assert(Mdim % Bsize == 0);
+  assert(Pdim % Bsize == 0);
+
+  /* Number of blocks in each dimension */
+  int Nblk = Ndim / Bsize;
+  int Mblk = Mdim / Bsize;
+  int Pblk = Pdim / Bsize;
+
+ #pragma omp target map(tofrom:C[0:Ndim*Mdim]) map(to:B[0:Pdim*Mdim], A[0:Ndim*Pdim]) uses_allocators(omp_pteam_mem_alloc)
+ #pragma omp teams  num_teams(Nblk*Mblk) thread_limit(Bsize*Bsize)
+ {
+
+  /* Team local arrays */
+  TYPE Awrk[Bsize*Bsize];
+  TYPE Bwrk[Bsize*Bsize];
+#pragma omp allocate(Awrk, Bwrk) allocator(omp_pteam_mem_alloc)
+
+#pragma omp distribute collapse(2)
+ for (ib=0; ib < Nblk; ib++){ /* Loop over blocks of C. One team per block */
+    for (jb=0; jb < Mblk; jb++){
+
+      for (kb=0; kb<Pblk; kb++){
+
+#pragma omp parallel num_threads(Bsize*Bsize)
+{
+        /* Copy block of A into pteam memory */
+        #pragma omp for collapse(2) nowait
+        for (i=ib*Bsize; i<((ib+1)*Bsize); i++){
+          for(k=kb*Bsize; k<((kb+1)*Bsize); k++){
+            Awrk[(i%Bsize)*Bsize + (k%Bsize)] = A[i*Pdim+k];
+          }
+        }
+
+        /* Copy block of B into pteam memory */
+        #pragma omp for collapse(2)
+        for (j=jb*Bsize; j<((jb+1)*Bsize); j++){
+          for(k=kb*Bsize; k<((kb+1)*Bsize); k++){
+            Bwrk[(k%Bsize)*Bsize + (j%Bsize)] = B[k*Mdim+j];
+          }
+        }
+
+
+        /* matrix multiply block */
+        #pragma omp for collapse(2)
+        for (i=ib*Bsize; i<((ib+1)*Bsize); i++){
+          for (j=jb*Bsize; j<((jb+1)*Bsize); j++){
+            /*for(k=kb*Bsize; k<((kb+1)*Bsize); k++){*/
+            for (k=0; k < Bsize; ++k){
+              /* C(i,j) = sum(over k) A(i,k) * B(k,j) */
+              *(C+(i*Mdim+j)) += Awrk[(i%Bsize)*Bsize + k] * Bwrk[k*Bsize + (j%Bsize)];
+            }
+          }
+        }
+}
+
+      }
+    }
+  }
+}
+}

--- a/mm_testbed.c
+++ b/mm_testbed.c
@@ -95,5 +95,8 @@ int main(int argc, char **argv)
    mm_tst_cases(NTRIALS, Ndim, Mdim, Pdim, A, B, C, &mm_gpu_block);
 
    printf("\n==================================================\n");
+   printf(" blocked ijk on a GPU with allocate directive %d %d %d\n", Ndim, Mdim, Pdim);
+   mm_tst_cases(NTRIALS, Ndim, Mdim, Pdim, A, B, C, &mm_gpu_block_allocate);
+   printf("\n==================================================\n");
 
 }

--- a/mm_testbed.c
+++ b/mm_testbed.c
@@ -43,6 +43,8 @@ void mm_gpu(int Ndim, int Mdim, int Pdim, TYPE *A, TYPE *B, TYPE *C);
 
 void mm_ikj_par (int Ndim, int Mdim, int Pdim, TYPE *A, TYPE *B, TYPE *C);
 
+void mm_gpu_block (int Ndim, int Mdim, int Pdim, TYPE *A, TYPE *B, TYPE *C);
+
 int main(int argc, char **argv)
 {
    int Ndim, Mdim, Pdim;   /* A[N][P], B[P][M], C[N][M] */
@@ -87,5 +89,11 @@ int main(int argc, char **argv)
    printf("\n==================================================\n");
    printf(" ijk on a GPU  %d %d %d\n", Ndim, Mdim, Pdim);
    mm_tst_cases(NTRIALS, Ndim, Mdim, Pdim, A, B, C, &mm_gpu);
+
+   printf("\n==================================================\n");
+   printf(" blocked ijk on a GPU  %d %d %d\n", Ndim, Mdim, Pdim);
+   mm_tst_cases(NTRIALS, Ndim, Mdim, Pdim, A, B, C, &mm_gpu_block);
+
+   printf("\n==================================================\n");
 
 }

--- a/mm_testbed.c
+++ b/mm_testbed.c
@@ -45,6 +45,8 @@ void mm_ikj_par (int Ndim, int Mdim, int Pdim, TYPE *A, TYPE *B, TYPE *C);
 
 void mm_gpu_block (int Ndim, int Mdim, int Pdim, TYPE *A, TYPE *B, TYPE *C);
 
+void mm_gpu_block_allocate (int Ndim, int Mdim, int Pdim, TYPE *A, TYPE *B, TYPE *C);
+
 int main(int argc, char **argv)
 {
    int Ndim, Mdim, Pdim;   /* A[N][P], B[P][M], C[N][M] */
@@ -91,12 +93,13 @@ int main(int argc, char **argv)
    mm_tst_cases(NTRIALS, Ndim, Mdim, Pdim, A, B, C, &mm_gpu);
 
    printf("\n==================================================\n");
-   printf(" blocked ijk on a GPU  %d %d %d\n", Ndim, Mdim, Pdim);
-   mm_tst_cases(NTRIALS, Ndim, Mdim, Pdim, A, B, C, &mm_gpu_block);
-
-   printf("\n==================================================\n");
    printf(" blocked ijk on a GPU with allocate directive %d %d %d\n", Ndim, Mdim, Pdim);
    mm_tst_cases(NTRIALS, Ndim, Mdim, Pdim, A, B, C, &mm_gpu_block_allocate);
+
+   printf("\n==================================================\n");
+   printf(" blocked ijk on a GPU with allocate clause %d %d %d\n", Ndim, Mdim, Pdim);
+   mm_tst_cases(NTRIALS, Ndim, Mdim, Pdim, A, B, C, &mm_gpu_block);
+
    printf("\n==================================================\n");
 
 }


### PR DESCRIPTION
There are two versions here.
The first uses the allocate directive - the local arrays are defined inside the team loop. The allocate directive is used to remind the compiler of where to put them.
This runs with the LLVM 12 compiler, but the performance is similar to the non-tiled version.

The second uses the allocate clause - the local arrays are defined outside the team loop. The private clause is needed to privatise them for each team, and then the allocate clause says where to put them instead.
This crashes with out-of-bounds memory access error with LLVM 12. 