### PR TITLE
Add cuBLAS version

### DIFF
--- a/Make_def_files/linux_nvhpc_gpu.def
+++ b/Make_def_files/linux_nvhpc_gpu.def
@@ -1,0 +1,17 @@
+# for llvm/clang compiler on linux 
+#
+#  Remember that before using this make.def, you need to set the -march=sm_?? flag below
+#
+# copy to make.def
+CC = nvc
+CPP = nvc++
+OPTFLAGS = -O3 -mp=gpu -gpu=cc75 -DUSE_CUBLAS
+
+CLINKER     = $(CC)
+LIBS        = -lm -L/nfs/software/x86_64/nvidia/hpc_sdk/22.5/Linux_x86_64/22.5/cuda/lib64/ -lcudart -lcublas
+
+CFLAGS    = $(OPTFLAGS)
+PRE= ./
+OBJ=o
+EXE=
+RM=rm

--- a/make.def
+++ b/make.def
@@ -1,18 +1,14 @@
-# for intel compiler on linux 
+# for llvm/clang compiler on linux 
 #
-#  Remember that before using this make.def, you need:
+#  Remember that before using this make.def, you need to set the -march=sm_?? flag below
 #
-# source /nfs/software/x86_64/inteloneapi-beta/2021.1.8/setvars.sh
-# module load intel/neo
-#
-# https://software.intel.com/content/www/us/en/develop/documentation/get-started-with-cpp-fortran-compiler-openmp/top.html
 # copy to make.def
-CC         = icx
-CPP         = $(CC)
-OPTFLAGS   = -O3 -fiopenmp -fopenmp-targets=spir64
+CC = nvc
+CPP = nvc++
+OPTFLAGS = -O3 -mp=gpu -gpu=cc75 -DUSE_CUBLAS
 
 CLINKER     = $(CC)
-LIBS        = -lm
+LIBS        = -lm -L/nfs/software/x86_64/nvidia/hpc_sdk/22.5/Linux_x86_64/22.5/cuda/lib64/ -lcudart -lcublas
 
 CFLAGS    = $(OPTFLAGS)
 PRE= ./

--- a/makefile
+++ b/makefile
@@ -9,7 +9,7 @@ EXES= mm_testbed$(EXE)
 
 MM_OBJS  = mm_testbed.$(OBJ) mm_utils.$(OBJ) mm_tst_cases.$(OBJ) \
            mm_ijk.$(OBJ) mm_ikj.$(OBJ) mm_ikj_par.$(OBJ) \
-	   mm_gpu.$(OBJ) mm_trans.$(OBJ)
+	   mm_gpu.$(OBJ) mm_trans.$(OBJ) mm_cublas.$(OBJ)
 
 all: $(EXES)
 

--- a/mm_cublas.c
+++ b/mm_cublas.c
@@ -1,0 +1,62 @@
+/*
+**  function: Matrix Multiplication ... using cuBLAS
+**
+**  HISTORY: Written by Tom Deakin, July 2022.
+*/
+#include "mm_utils.h"
+
+#ifdef USE_CUBLAS
+
+#include <cuda_runtime.h>
+#include "cublas_v2.h"
+
+void mm_cublas(int Ndim, int Mdim, int Pdim, TYPE *A, TYPE *B, TYPE *C){
+  // Initalize cuBLAS Library
+  cublasHandle_t handle;
+  cublasStatus_t err;
+
+  err = cublasCreate(&handle);
+  if (err != CUBLAS_STATUS_SUCCESS) {
+    printf("cuBLAS Create error\n");
+    return;
+  }
+
+  // Target data region to map and convert arrays
+  #pragma omp target data map(tofrom:C[0:Ndim*Mdim]) map(to:B[0:Pdim*Mdim],A[0:Ndim*Pdim]) use_device_ptr(A, B, C)
+  {
+
+  // Call dgemm from cuBLAS
+  // Note cuBLAS assumes column-major matrices, so we swap the order of arguments to avoid an explicit transpose
+  TYPE alpha = 1.0;
+  TYPE beta = 0.0;
+
+  if (sizeof(TYPE) == sizeof(double)) {
+    err = cublasDgemm(handle, CUBLAS_OP_N, CUBLAS_OP_N,
+      Mdim, Ndim, Pdim,
+      &alpha,
+      B, Mdim,
+      A, Pdim,
+      &beta,
+      C, Mdim);
+  }
+  else {
+    printf("Only implemented for TYPE == double\n");
+    return;
+  }
+
+  if (err != CUBLAS_STATUS_SUCCESS) {
+    printf("cuBLAS Dgemm error\n");
+  }
+
+  // Synchronize cuBLAS call
+  cudaDeviceSynchronize();
+
+  } // end target data region
+
+  cublasDestroy(handle);
+}
+
+#else
+void mm_cublas(int Ndim, int Mdim, int Pdim, TYPE *A, TYPE *B, TYPE *C){ }
+#endif
+

--- a/mm_gpu_block.c
+++ b/mm_gpu_block.c
@@ -8,6 +8,8 @@
 
 #include <assert.h>
 
+#ifdef USE_ALLOCATE
+
 void mm_gpu_block(int Ndim, int Mdim, int Pdim, TYPE *A, TYPE *B, TYPE *C){
   int i, j, k;
   const int Bsize = 8;
@@ -69,3 +71,7 @@ void mm_gpu_block(int Ndim, int Mdim, int Pdim, TYPE *A, TYPE *B, TYPE *C){
     }
   }
 }
+
+#else
+void mm_gpu_block(int Ndim, int Mdim, int Pdim, TYPE *A, TYPE *B, TYPE *C){}
+#endif

--- a/mm_gpu_block_allocate_directive.c
+++ b/mm_gpu_block_allocate_directive.c
@@ -10,6 +10,8 @@
 
 #define Bsize 8
 
+#ifdef USE_ALLOCATE
+
 void mm_gpu_block_allocate(int Ndim, int Mdim, int Pdim, TYPE *A, TYPE *B, TYPE *C){
   //int i, j, k;
   //int ib, jb, kb;
@@ -76,3 +78,7 @@ void mm_gpu_block_allocate(int Ndim, int Mdim, int Pdim, TYPE *A, TYPE *B, TYPE 
   }
 }
 }
+
+#else
+void mm_gpu_block_allocate(int Ndim, int Mdim, int Pdim, TYPE *A, TYPE *B, TYPE *C){ }
+#endif

--- a/mm_testbed.c
+++ b/mm_testbed.c
@@ -96,6 +96,7 @@ int main(int argc, char **argv)
    printf(" ijk on a GPU  %d %d %d\n", Ndim, Mdim, Pdim);
    mm_tst_cases(NTRIALS, Ndim, Mdim, Pdim, A, B, C, &mm_gpu);
 
+   #ifdef USE_ALLOCATE
    printf("\n==================================================\n");
    printf(" blocked ijk on a GPU with allocate directive %d %d %d\n", Ndim, Mdim, Pdim);
    mm_tst_cases(NTRIALS, Ndim, Mdim, Pdim, A, B, C, &mm_gpu_block_allocate);
@@ -103,6 +104,7 @@ int main(int argc, char **argv)
    printf("\n==================================================\n");
    printf(" blocked ijk on a GPU with allocate clause %d %d %d\n", Ndim, Mdim, Pdim);
    mm_tst_cases(NTRIALS, Ndim, Mdim, Pdim, A, B, C, &mm_gpu_block);
+   #endif
 
    #ifdef USE_CUBLAS
    printf("\n==================================================\n");

--- a/mm_testbed.c
+++ b/mm_testbed.c
@@ -43,6 +43,10 @@ void mm_gpu(int Ndim, int Mdim, int Pdim, TYPE *A, TYPE *B, TYPE *C);
 
 void mm_ikj_par (int Ndim, int Mdim, int Pdim, TYPE *A, TYPE *B, TYPE *C);
 
+#ifdef USE_CUBLAS
+void mm_cublas (int Ndim, int Mdim, int Pdim, TYPE *A, TYPE *B, TYPE *C);
+#endif
+
 int main(int argc, char **argv)
 {
    int Ndim, Mdim, Pdim;   /* A[N][P], B[P][M], C[N][M] */
@@ -88,4 +92,9 @@ int main(int argc, char **argv)
    printf(" ijk on a GPU  %d %d %d\n", Ndim, Mdim, Pdim);
    mm_tst_cases(NTRIALS, Ndim, Mdim, Pdim, A, B, C, &mm_gpu);
 
+   #ifdef USE_CUBLAS
+   printf("\n==================================================\n");
+   printf(" ijk on a GPU with cuBLAS  %d %d %d\n", Ndim, Mdim, Pdim);
+   mm_tst_cases(NTRIALS, Ndim, Mdim, Pdim, A, B, C, &mm_cublas);
+   #endif
 }

--- a/mm_utils.h
+++ b/mm_utils.h
@@ -1,5 +1,6 @@
 #include <omp.h>
 #include <stdio.h>
+#include <stdlib.h>
 #ifdef APPLE
 #include <stdlib.h>
 #endif


### PR DESCRIPTION
This adds a new test function which uses the cuBLAS DGEMM routine for matrix-multiplication.

The cuBLAS is guarded with a pre-processor define so the code should still still build OK on non-NVIDIA systems without the cuBLAS library.

I've had to add a pre-processor guard around the allocate variants, as these are not currently implemented in NVHPC.

I've used OpenMP to map the data to/from the device. An alternative is to use `cudaMemcpy` - the way this testbed works either approach could be valid. Would value feedback on this approach.

I've also included a `linux_nvhpc_gpu.def` file which has the correct library paths for the Zoo.

Results on the GTX 2080 Ti with NVHPC 22.1. Peak is around 412 GFLOP/s (according to [this](https://www.techpowerup.com/gpu-specs/geforce-rtx-2080-ti.c3305)), which is achievable with larger matrices (and hacking the code to skip the slow serial versions).
```
$ module load /nfs/software/x86_64/nvidia/hpc_sdk/22.1/modulefiles/nvhpc/22.1
$ make mm_testbed -B
$ OMP_NUM_THREADS=8 ./mm_testbed
==================================================                                                                                                                    
 triple loop, ijk case 400 1200 800                                                                                                                                   
                                                                                                                                                                      
 constant matrices  400 1200 800                                                                                                                                      
 mult: ave=0.242943, min=0.218986, max=0.338241 secs                                                                                                                  
 mult: ave=3161.238444, min=2270.569719, max=3507.076779 Mflops                                                                                                       
                                                                                                                                                                      
 progression matrices  400 1200 800                                                                                                                                   
 mult: ave=0.219171, min=0.219127, max=0.219244 secs                                                                                                                  
 mult: ave=3504.116284, min=3502.946436, max=3504.817805 Mflops                                                                                                       
                                                                                                                                                                      
==================================================                                                                                                                    
 triple loop, ikj case 400 1200 800                                                                                                                                   
                                                                                                                                                                      
 constant matrices  400 1200 800                                                                                                                                      
 mult: ave=0.263986, min=0.263873, max=0.264100 secs                                                                                                                  
 mult: ave=2909.240289, min=2907.988575, max=2910.489926 Mflops                                                                                                       

 progression matrices  400 1200 800
 mult: ave=0.264084, min=0.264023, max=0.264264 secs 
 mult: ave=2908.162899, min=2906.183550, max=2908.836765 Mflops 

==================================================
 triple loop, ikj par case 400 1200 800
 OMP MAX NUM THREADS = 8

 constant matrices  400 1200 800
 mult: ave=0.191489, min=0.160413, max=0.232224 secs 
 mult: ave=4010.665647, min=3307.151892, max=4787.641099 Mflops 

 progression matrices  400 1200 800
 mult: ave=0.198430, min=0.178785, max=0.203366 secs 
 mult: ave=3870.382236, min=3776.441708, max=4295.660329 Mflops 

==================================================
 ijk on a GPU  400 1200 800

 constant matrices  400 1200 800
 mult: ave=0.354856, min=0.208893, max=0.937996 secs 
 mult: ave=2164.259254, min=818.766896, max=3676.522320 Mflops 

 progression matrices  400 1200 800
 mult: ave=0.209229, min=0.209028, max=0.209460 secs 
 mult: ave=3670.626098, min=3666.570832, max=3674.148819 Mflops 

==================================================
 ijk on a GPU with cuBLAS  400 1200 800

 constant matrices  400 1200 800
 mult: ave=0.031412, min=0.004468, max=0.139076 secs 
 mult: ave=24449.380740, min=5522.160764, max=171890.366702 Mflops 

 progression matrices  400 1200 800
 mult: ave=0.004530, min=0.004466, max=0.004690 secs 
 mult: ave=169534.613587, min=163746.719805, max=171972.957771 Mflops 

==================================================
```

Larger input, skipped to this test with a `goto`.
```
$ ./mm_testbed 10000

==================================================
 ijk on a GPU with cuBLAS  10000 30000 20000

 constant matrices  10000 30000 20000
 mult: ave=24.846501, min=24.673455, max=25.264608 secs 
 mult: ave=482965.384134, min=474972.738326, max=486352.640927 Mflops 

 progression matrices  10000 30000 20000
 5 errors
 mult: ave=24.861846, min=24.858268, max=24.864028 secs 
 mult: ave=482667.288956, min=482624.939576, max=482736.769477 Mflops 

==================================================

```

Note, the errors for the progression matrix are caused due to the values of `Aval` and `Bval`.  Setting `Aval = 2.0` and `Bval = 0.5` fixes this, so I'm not 100% on the algebra of the true solution in the code. Using these values creates `1.0` so they disappear so the formula from Gradshteyn and Ryzhik holds. 

